### PR TITLE
[REFACTOR] 이벤트의 '대관 진행 중' 상태 제거

### DIFF
--- a/src/main/java/project/luckybooky/domain/event/entity/Event.java
+++ b/src/main/java/project/luckybooky/domain/event/entity/Event.java
@@ -120,7 +120,6 @@ public class Event extends BaseEntity {
 
     /** 대관 신청 **/
     public void venueRegister() {
-        eventStatus = EventStatus.VENUE_RESERVATION_IN_PROGRESS;
         hostEventButtonState = HostEventButtonState.VENUE_RESERVATION_IN_PROGRESS;
         participantEventButtonState = ParticipantEventButtonState.VENUE_RESERVATION_IN_PROGRESS;
     }

--- a/src/main/java/project/luckybooky/domain/event/entity/type/EventStatus.java
+++ b/src/main/java/project/luckybooky/domain/event/entity/type/EventStatus.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 public enum EventStatus {
     RECRUITING("모집 중"),
     RECRUITED("모집 완료"),
-    VENUE_RESERVATION_IN_PROGRESS("대관 진행 중"),
     COMPLETED("상영 완료"),
     CANCELLED("상영 취소"),
     VENUE_CONFIRMED("대관 확정"),

--- a/src/main/java/project/luckybooky/domain/participation/service/ParticipationService.java
+++ b/src/main/java/project/luckybooky/domain/participation/service/ParticipationService.java
@@ -54,8 +54,7 @@ public class ParticipationService {
         List<EventStatus> statuses = (type == 0)
                 ? List.of(
                 EventStatus.RECRUITING,
-                EventStatus.RECRUITED,
-                EventStatus.VENUE_RESERVATION_IN_PROGRESS
+                EventStatus.RECRUITED
         )
                 : List.of(
                 EventStatus.COMPLETED,


### PR DESCRIPTION
## Issue

- #110 


## Summary

- 이벤트 상태 중 '대관 진행 중' 상태를 없애고, '모집 완료' 상태로 귀속시켰습니다.

## Describe your code

- 코드 설명 (설명이 필요한 코드가 있다고 생각하시면 간단하게 작성해주세요.)

# Check
- [ ] Reviewers 등록을 하였나요?
- [ ] Assignees 등록을 하였나요?
- [ ] 라벨 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
