### PR TITLE
[REFACTOR] 피드백 엔티티와 이벤트 엔티티의 연관관계 제거

### DIFF
--- a/src/main/java/project/luckybooky/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/project/luckybooky/domain/feedback/controller/FeedbackController.java
@@ -24,15 +24,14 @@ public class FeedbackController {
     private final FeedbackService feedbackService;
     private final UserContextService userContextService;
 
-    @Operation(summary = "피드백 생성", description = "해당하는 값을 넣어주세요 !")
-    @PostMapping("/{eventId}")
-    public CommonResponse<FeedbackCreateResultDTO> createFeedback(
-            @PathVariable("eventId") Long eventId,
-            @RequestBody FeedbackRequest.FeedbackCreateRequestDTO request
-    ) {
+    @Operation(summary = "피드백 생성", description = "해당하는 값을 넣어주세요 !<br><br>" +
+            "isSatisfied: true -> 만족, false -> 불만족 <br>" +
+            "feedback: 반드시 피드백 보기에 해당하는 문장 그대로 넣어주세요 ! (ex, '내게 꼭 맞는 이벤트를 추천해줘요') <br> comment: 의견 (텍스트) ")
+    @PostMapping
+    public CommonResponse<FeedbackCreateResultDTO> createFeedback(@RequestBody FeedbackRequest.FeedbackCreateRequestDTO request) {
         Long userId = userContextService.getUserId();
         FeedbackResponse.FeedbackCreateResultDTO resultDto =
-                feedbackService.createFeedback(request, userId, eventId);
+                feedbackService.createFeedback(request, userId);
 
         return CommonResponse.of(ResultCode.CREATED, resultDto);
     }

--- a/src/main/java/project/luckybooky/domain/feedback/converter/FeedbackConverter.java
+++ b/src/main/java/project/luckybooky/domain/feedback/converter/FeedbackConverter.java
@@ -16,7 +16,6 @@ public class FeedbackConverter {
             FeedbackRequest.FeedbackCreateRequestDTO request,
             PositiveFeedback positiveFeedback,
             NegativeFeedback negativeFeedback,
-            Event event,
             User user
     ) {
         return Feedback.builder()
@@ -24,7 +23,6 @@ public class FeedbackConverter {
                 .positiveFeedback(positiveFeedback)
                 .negativeFeedback(negativeFeedback)
                 .comment(request.getComment())
-                .event(event)
                 .user(user)
                 .build();
     }

--- a/src/main/java/project/luckybooky/domain/feedback/entity/Feedback.java
+++ b/src/main/java/project/luckybooky/domain/feedback/entity/Feedback.java
@@ -24,10 +24,6 @@ public class Feedback extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id")
-    private Event event;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/project/luckybooky/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/project/luckybooky/domain/feedback/service/FeedbackService.java
@@ -20,10 +20,9 @@ import project.luckybooky.domain.user.service.UserTypeService;
 public class FeedbackService {
     private final FeedbackRepository feedbackRepository;
     private final UserTypeService userTypeService;
-    private final EventService eventService;
 
     @Transactional
-    public FeedbackResponse.FeedbackCreateResultDTO createFeedback(FeedbackRequest.FeedbackCreateRequestDTO request, Long userId, Long eventId) {
+    public FeedbackResponse.FeedbackCreateResultDTO createFeedback(FeedbackRequest.FeedbackCreateRequestDTO request, Long userId) {
         PositiveFeedback positiveFeedback;
         NegativeFeedback negativeFeedback;
 
@@ -37,9 +36,8 @@ public class FeedbackService {
         }
 
         User user = userTypeService.findOne(userId);
-        Event event = eventService.findOne(eventId);
 
-        Feedback feedback = FeedbackConverter.toFeedback(request, positiveFeedback, negativeFeedback, event, user);
+        Feedback feedback = FeedbackConverter.toFeedback(request, positiveFeedback, negativeFeedback, user);
         feedbackRepository.save(feedback);
 
         return FeedbackConverter.toFeedbackCreateResultDTO(feedback);


### PR DESCRIPTION
## Issue

- #114 


## Summary

- 피드백 엔티티와 이벤트 엔티티의 연관관계를 제거하였습니다.
- 피드백 엔티티 생성 시 이벤트 ID 값을 받지 않도록 수정하였습니다.

## Describe your code

- 코드 설명 (설명이 필요한 코드가 있다고 생각하시면 간단하게 작성해주세요.)

# Check
- [ ] Reviewers 등록을 하였나요?
- [ ] Assignees 등록을 하였나요?
- [ ] 라벨 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
