### PR TITLE
[FEAT] 이벤트 신청 동시성 제어를 위한 분산락 적용 및 테스트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+tokens.json
+/scripts/k6/tokens.csv

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.50.0'
 
     // email
     implementation 'org.springframework.boot:spring-boot-starter-mail'

--- a/scripts/k6/event-apply-race-test.js
+++ b/scripts/k6/event-apply-race-test.js
@@ -1,0 +1,42 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+import {SharedArray} from 'k6/data';
+import {parse} from 'https://jslib.k6.io/papaparse/5.1.1/index.js';
+
+export let options = {
+    vus: __ENV.VUS ? parseInt(__ENV.VUS) : 200,   // 동시 VU 수
+    duration: __ENV.DURATION || '30s',            // 총 실행 시간
+    thresholds: {http_req_failed: ['rate<0.05']} // 실패율 5% 미만 허용
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const EVENT_ID = __ENV.EVENT_ID || '1';
+
+const tokens = new SharedArray('tokens', () =>
+    parse(open('tokens.csv'), {header: true}).data
+);
+
+export function setup() {
+    return {targetTs: Date.now() + 15_000};
+}
+
+export default function (data) {
+    const margin = 20; // ms
+    while (Date.now() < data.targetTs - margin) {
+        sleep(0.005);
+    }
+
+    const token = tokens[(__VU - 1) % tokens.length].token;
+    const res = http.post(
+        `${BASE_URL}/api/events/${EVENT_ID}/register`,
+        {},
+        {headers: {Authorization: `Bearer ${token}`}}
+    );
+
+    check(res, {
+        'registered': r => r.status === 200,
+        'full': r => r.status === 400 && r.json('code') === 'EVENT_402',
+    }) || console.error(`VU=${__VU} ✗ ${res.status} ${res.body}`);
+
+    sleep(45);
+}

--- a/scripts/k6/event-apply-test .js
+++ b/scripts/k6/event-apply-test .js
@@ -17,7 +17,7 @@ export let options = {
 };
 
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
-const EVENT_ID = __ENV.EVENT_ID || '1';
+const EVENT_ID = __ENV.EVENT_ID || '3';
 
 export default function () {
     // VU별 토큰 할당 (없으면 ENV Fallback)

--- a/scripts/k6/load-test-recruit.js
+++ b/scripts/k6/load-test-recruit.js
@@ -9,7 +9,7 @@ const tokens = new SharedArray('tokens', () => {
 });
 
 export let options = {
-    vus: __ENV.VUS ? parseInt(__ENV.VUS) : 100,
+    vus: __ENV.VUS ? parseInt(__ENV.VUS) : 200,
     duration: __ENV.DURATION || '1m',
     thresholds: {
         http_req_failed: ['rate<0.01'],

--- a/scripts/k6/load-test-recruit.js
+++ b/scripts/k6/load-test-recruit.js
@@ -1,0 +1,39 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+import {SharedArray} from 'k6/data';
+import {parse} from 'https://jslib.k6.io/papaparse/5.1.1/index.js';
+
+// CSV 에서 토큰 로드 (optional)
+const tokens = new SharedArray('tokens', () => {
+    return parse(open('tokens.csv'), {header: true}).data;
+});
+
+export let options = {
+    vus: __ENV.VUS ? parseInt(__ENV.VUS) : 100,
+    duration: __ENV.DURATION || '1m',
+    thresholds: {
+        http_req_duration: ['p(95)<500'],
+        http_req_failed: ['rate<0.01'],
+    },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const EVENT_ID = __ENV.EVENT_ID || '1';
+
+export default function () {
+    const token = tokens.length
+        ? tokens[(__VU - 1) % tokens.length].token
+        : __ENV.AUTH_TOKEN;
+
+    let res = http.post(
+        `${BASE_URL}/api/events/${EVENT_ID}/recruit`,
+        {},
+        {headers: {Authorization: `Bearer ${token}`}}
+    );
+
+    check(res, {
+        'status is OK': (r) => r.status === 200 || r.status === 201,
+    });
+
+    sleep(0.1);
+}

--- a/scripts/k6/load-test-recruit.js
+++ b/scripts/k6/load-test-recruit.js
@@ -3,7 +3,7 @@ import {check, sleep} from 'k6';
 import {SharedArray} from 'k6/data';
 import {parse} from 'https://jslib.k6.io/papaparse/5.1.1/index.js';
 
-// CSV 에서 토큰 로드 (optional)
+// tokens.csv가 있다면 로드
 const tokens = new SharedArray('tokens', () => {
     return parse(open('tokens.csv'), {header: true}).data;
 });
@@ -12,7 +12,6 @@ export let options = {
     vus: __ENV.VUS ? parseInt(__ENV.VUS) : 100,
     duration: __ENV.DURATION || '1m',
     thresholds: {
-        http_req_duration: ['p(95)<500'],
         http_req_failed: ['rate<0.01'],
     },
 };
@@ -21,19 +20,34 @@ const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
 const EVENT_ID = __ENV.EVENT_ID || '1';
 
 export default function () {
+    // VU별 토큰 할당 (없으면 ENV Fallback)
     const token = tokens.length
         ? tokens[(__VU - 1) % tokens.length].token
         : __ENV.AUTH_TOKEN;
 
-    let res = http.post(
-        `${BASE_URL}/api/events/${EVENT_ID}/recruit`,
-        {},
-        {headers: {Authorization: `Bearer ${token}`}}
-    );
+    const url = `${BASE_URL}/api/events/${EVENT_ID}/register`;
+    const params = {
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+        },
+    };
 
-    check(res, {
-        'status is OK': (r) => r.status === 200 || r.status === 201,
+    // 요청 보내기
+    let res = http.post(url, {}, params);
+
+    // 검증 & 실패 로그
+    let ok = check(res, {
+        'status is 200 or 201': (r) => r.status === 200 || r.status === 201,
+        'response code COMMON_200': (r) => r.json('code') === 'COMMON_200',
     });
+
+    if (!ok) {
+        console.error(`VU=${__VU} ▶︎ 요청 실패:
+    URL: ${url}
+    status: ${res.status}
+    body: ${res.body.substring(0, 200)}...`);
+    }
 
     sleep(0.1);
 }

--- a/src/main/java/project/luckybooky/domain/event/controller/EventController.java
+++ b/src/main/java/project/luckybooky/domain/event/controller/EventController.java
@@ -63,8 +63,8 @@ public class EventController {
     public CommonResponse<String> registerEvent(@PathVariable("eventId") Long eventId) {
         Long userId = userContextService.getUserId();
 
-        participationService.createParticipation(userId, eventId, Boolean.FALSE);
-        eventService.registerEvent(eventId, Boolean.TRUE);
+        //participationService.createParticipation(userId, eventId, Boolean.FALSE);
+        eventService.registerEvent(userId, eventId);
 
         return CommonResponse.of(ResultCode.OK, EventConstants.REGISTER_SUCCESS.getMessage());
     }
@@ -75,8 +75,9 @@ public class EventController {
         Long userId = userContextService.getUserId();
 
         participationService.deleteParticipation(userId, eventId);
-        eventService.registerEvent(eventId, Boolean.FALSE);
-
+        //eventService.registerEvent(userId, eventId);
+        eventService.cancelEvent(userId, eventId);
+        
         return CommonResponse.of(ResultCode.OK, EventConstants.REGISTER_CANCEL_SUCCESS.getMessage());
     }
 
@@ -124,7 +125,8 @@ public class EventController {
             @RequestParam(defaultValue = "10") int size,
             @RequestParam String category
     ) {
-        EventResponse.ReadEventListWithPageResultDTO result = eventService.readEventListByCategory(category, page, size);
+        EventResponse.ReadEventListWithPageResultDTO result = eventService.readEventListByCategory(category, page,
+                size);
 
         return CommonResponse.of(ResultCode.OK, result);
     }
@@ -170,4 +172,5 @@ public class EventController {
 
         return CommonResponse.of(ResultCode.OK, list);
     }
+
 }

--- a/src/main/java/project/luckybooky/domain/event/controller/TestEventController.java
+++ b/src/main/java/project/luckybooky/domain/event/controller/TestEventController.java
@@ -1,0 +1,39 @@
+package project.luckybooky.domain.event.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import project.luckybooky.domain.event.dto.response.EventParticipantsResponse;
+import project.luckybooky.domain.event.service.EventService;
+import project.luckybooky.global.apiPayload.response.CommonResponse;
+import project.luckybooky.global.apiPayload.response.ResultCode;
+
+@RestController
+@Profile("dev")
+@RequestMapping("/api/test/events")
+@RequiredArgsConstructor
+public class TestEventController {
+
+    private final EventService eventService;
+
+
+    // 테스트 전용: 특정 이벤트의 모든 참가자를 인증 없이 한 번에 취소합니다. 알림 발송은 수행되지 않습니다.
+    @DeleteMapping("/{eventId}/participants")
+    public CommonResponse<Integer> cancelAllParticipants(@PathVariable Long eventId) {
+        eventService.cancelAllParticipants(eventId);
+        return CommonResponse.ok(ResultCode.OK);
+    }
+
+    // 테스트 전용: 특정 이벤트에 참여 중인 사용자 목록 조회
+    @GetMapping("/{eventId}/participants")
+    public CommonResponse<EventParticipantsResponse> getParticipants(
+            @PathVariable Long eventId) {
+        EventParticipantsResponse participants = eventService.getEventParticipants(eventId);
+        return CommonResponse.of(ResultCode.OK, participants);
+    }
+
+}

--- a/src/main/java/project/luckybooky/domain/event/dto/response/EventParticipantsResponse.java
+++ b/src/main/java/project/luckybooky/domain/event/dto/response/EventParticipantsResponse.java
@@ -1,0 +1,12 @@
+package project.luckybooky.domain.event.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EventParticipantsResponse {
+    private List<ParticipantDTO> participants;
+    private long totalParticipantsCount;
+}

--- a/src/main/java/project/luckybooky/domain/event/dto/response/ParticipantDTO.java
+++ b/src/main/java/project/luckybooky/domain/event/dto/response/ParticipantDTO.java
@@ -1,0 +1,12 @@
+package project.luckybooky.domain.event.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ParticipantDTO {
+    private Long userId;
+    private String username;
+    private String profileImageUrl;
+}

--- a/src/main/java/project/luckybooky/domain/event/entity/Event.java
+++ b/src/main/java/project/luckybooky/domain/event/entity/Event.java
@@ -50,6 +50,7 @@ public class Event extends BaseEntity {
     @JoinColumn(name = "category_id")
     private Category category;
 
+    @Builder.Default
     @OneToMany(mappedBy = "event", cascade = CascadeType.ALL)
     private List<Participation> participationList = new ArrayList<>();
 

--- a/src/main/java/project/luckybooky/domain/event/entity/Event.java
+++ b/src/main/java/project/luckybooky/domain/event/entity/Event.java
@@ -118,16 +118,17 @@ public class Event extends BaseEntity {
 
     public void updateCurrentParticipants(Boolean isPlus) {
         if (isPlus) {
-            if (this.currentParticipants + 1 > this.maxParticipants) {
+            if (currentParticipants + 1 > maxParticipants) {
                 throw new BusinessException(ErrorCode.EVENT_FULL);
             }
-            this.currentParticipants++;
+            currentParticipants++;
         } else {
-            if (this.currentParticipants <= 0) {
+            if (currentParticipants <= 0) {
                 throw new BusinessException(ErrorCode.INVALID_OPERATION);
             }
+            currentParticipants--;
+
         }
-        currentParticipants += isPlus ? 1 : -1;
     }
 
     /**
@@ -181,5 +182,9 @@ public class Event extends BaseEntity {
      **/
     public void screeningProcess(Integer type) {
         eventStatus = (type == 0) ? EventStatus.COMPLETED : EventStatus.CANCELLED;
+    }
+
+    public void resetCurrentParticipants() {
+        this.currentParticipants = 0;
     }
 }

--- a/src/main/java/project/luckybooky/domain/participation/repository/ParticipationRepository.java
+++ b/src/main/java/project/luckybooky/domain/participation/repository/ParticipationRepository.java
@@ -43,4 +43,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 
     boolean existsByUserIdAndEventId(Long userId, Long eventId);
 
+    List<Participation> findAllByEventIdAndParticipateRole(Long eventId, ParticipateRole role);
+
+
 }

--- a/src/main/java/project/luckybooky/domain/user/controller/TestUserTokenController.java
+++ b/src/main/java/project/luckybooky/domain/user/controller/TestUserTokenController.java
@@ -1,0 +1,28 @@
+package project.luckybooky.domain.user.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import project.luckybooky.domain.user.repository.UserRepository;
+
+@RestController
+@Profile("dev")
+@RequestMapping("/api/test/users")
+@RequiredArgsConstructor
+public class TestUserTokenController {
+    private final UserRepository userRepository;
+
+    @GetMapping("/tokens")
+    public List<UserTokenDto> getAllUserTokens() {
+        return userRepository.findAll().stream()
+                .map(u -> new UserTokenDto(u.getUsername(), u.getAccessToken()))
+                .collect(Collectors.toList());
+    }
+
+    public record UserTokenDto(String username, String token) {
+    }
+}

--- a/src/main/java/project/luckybooky/domain/user/entity/User.java
+++ b/src/main/java/project/luckybooky/domain/user/entity/User.java
@@ -1,6 +1,5 @@
 package project.luckybooky.domain.user.entity;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -9,17 +8,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Pattern;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import project.luckybooky.domain.ticket.entity.Ticket;
 import project.luckybooky.global.entity.BaseEntity;
 
 @Getter
@@ -55,9 +50,11 @@ public class User extends BaseEntity {
     @Column(name = "refresh_token", columnDefinition = "TEXT")
     private String refreshToken;
 
+    @Builder.Default
     @Column(name = "host_experience_count", nullable = false)
     private int hostExperienceCount = 0;
 
+    @Builder.Default
     @Column(name = "participation_experience_count", nullable = false)
     private int participationExperienceCount = 0;
 

--- a/src/main/java/project/luckybooky/domain/user/repository/init/UserInitializer.java
+++ b/src/main/java/project/luckybooky/domain/user/repository/init/UserInitializer.java
@@ -1,6 +1,8 @@
 package project.luckybooky.domain.user.repository.init;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -20,27 +22,32 @@ import project.luckybooky.global.jwt.JwtUtil;
 public class UserInitializer implements ApplicationRunner {
 
     private final UserRepository userRepository;
-    private final JwtUtil        jwtUtil;
+    private final JwtUtil jwtUtil;
 
     @Override
     @Transactional
     public void run(ApplicationArguments args) {
 
         /* 최초 기동 시 한 번만 삽입 */
-        if (userRepository.count() > 0) return;
+        if (userRepository.count() > 0) {
+            return;
+        }
 
-        List<User> guests = List.of(
-                buildGuest("guest1@example.com", "게스트1", "+821012300001", UserType.MOVIE_DETAIL_COLLECTOR),
-                buildGuest("guest2@example.com", "게스트2", "+821012300002", UserType.MOVIE_DETAIL_COLLECTOR),
-                buildGuest("guest3@example.com", "게스트3", "+821012300003", UserType.DRAMA_STORY_IMMERSER),
-                buildGuest("guest4@example.com", "게스트4", "+821012300004", UserType.SPORTS_FULL_SUPPORTER)
-        );
+        List<User> guests = IntStream.rangeClosed(1, 200)
+                .mapToObj(i -> buildGuest(
+                        "guest" + i + "@example.com",
+                        "게스트" + i,
+                        "+8210123" + String.format("%04d", i),
+                        UserType.MOVIE_DETAIL_COLLECTOR))
+                .peek(this::attachJwtTokens)
+                .collect(Collectors.toList());
 
-        guests.forEach(this::attachJwtTokens);
         userRepository.saveAll(guests);
     }
 
-    /** 게스트 회원 기본 빌더 */
+    /**
+     * 게스트 회원 기본 빌더
+     */
     private User buildGuest(String email, String username, String phone, UserType type) {
         return User.builder()
                 .email(email)
@@ -53,9 +60,11 @@ public class UserInitializer implements ApplicationRunner {
                 .build();
     }
 
-    /** Access / Refresh Token 생성 & 주입 */
+    /**
+     * Access / Refresh Token 생성 & 주입
+     */
     private void attachJwtTokens(User u) {
-        String accessToken  = jwtUtil.createAccessToken(u.getEmail());     // 15분 만료 등
+        String accessToken = jwtUtil.createAccessToken(u.getEmail());     // 15분 만료 등
         String refreshToken = jwtUtil.createAccessToken(u.getEmail());    // 2주 만료 등
         u.setAccessToken(accessToken);
         u.setRefreshToken(refreshToken);

--- a/src/main/java/project/luckybooky/global/apiPayload/error/dto/ErrorCode.java
+++ b/src/main/java/project/luckybooky/global/apiPayload/error/dto/ErrorCode.java
@@ -86,8 +86,10 @@ public enum ErrorCode implements BaseStatus {
     TICKET_NOT_FOUND(HttpStatus.BAD_REQUEST, "TICKET_401", "해당 티켓을 찾을 수 없습니다."),
 
     NOTIFICATION_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "NOTIFICATION_400", "알림 타입을 찾을 수 없습니다."),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "HOST_403", "접근이 거부되었습니다.");
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "HOST_403", "접근이 거부되었습니다."),
 
+    // Redis 관련
+    SYSTEM_BUSY(HttpStatus.SERVICE_UNAVAILABLE, "SYSTEM_503", "시스템이 바쁩니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/project/luckybooky/global/config/RedissonConfig.java
+++ b/src/main/java/project/luckybooky/global/config/RedissonConfig.java
@@ -1,0 +1,26 @@
+package project.luckybooky.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean(destroyMethod = "shutdown")
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + redisHost + ":" + redisPort);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/project/luckybooky/global/config/SecurityConfig.java
+++ b/src/main/java/project/luckybooky/global/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // 이벤트 상세 조회 비로그인 유저 허용
                         .requestMatchers(HttpMethod.GET, "/api/events/anonymous/**").permitAll()
-
+                        .requestMatchers(HttpMethod.GET, "/api/test/users/tokens/**").permitAll()
                         .requestMatchers("/", "/api/health").permitAll() // 인증 없이 접근 허용
                         .requestMatchers("/", "/index.html", "/static/**", "/favicon.ico").permitAll() // 정적 파일 허용
                         .requestMatchers("/**").permitAll()  // 모든 요청 허용 (테스트용)

--- a/src/main/java/project/luckybooky/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/project/luckybooky/global/jwt/JwtAuthenticationFilter.java
@@ -16,7 +16,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
     private static final List<String> EXCLUDED_URLS = List.of(
             "/api/auth/login/kakao", "/swagger-ui", "/v3/api-docs", "/swagger-resources", "/api/events/anonymous",
-            "/api/test/users/tokens"
+            "/api/test/users/tokens", "api/test/events/"
     );
 
     public JwtAuthenticationFilter(JwtUtil jwtUtil) {

--- a/src/main/java/project/luckybooky/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/project/luckybooky/global/jwt/JwtAuthenticationFilter.java
@@ -16,7 +16,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
     private static final List<String> EXCLUDED_URLS = List.of(
             "/api/auth/login/kakao", "/swagger-ui", "/v3/api-docs", "/swagger-resources", "/api/events/anonymous",
-            "api/test/users/tokens"
+            "/api/test/users/tokens"
     );
 
     public JwtAuthenticationFilter(JwtUtil jwtUtil) {

--- a/src/main/java/project/luckybooky/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/project/luckybooky/global/jwt/JwtAuthenticationFilter.java
@@ -15,7 +15,8 @@ import project.luckybooky.global.oauth.util.CookieUtil;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
     private static final List<String> EXCLUDED_URLS = List.of(
-            "/api/auth/login/kakao", "/swagger-ui", "/v3/api-docs", "/swagger-resources", "/api/events/anonymous"
+            "/api/auth/login/kakao", "/swagger-ui", "/v3/api-docs", "/swagger-resources", "/api/events/anonymous",
+            "api/test/users/tokens"
     );
 
     public JwtAuthenticationFilter(JwtUtil jwtUtil) {


### PR DESCRIPTION
## Issue

- #135 


## Summary

- k6로 현재 상태에서 이벤트 신청이 동시성 이슈를 견딜 수 있는지 부하테스트 진행 -> 최대 참여 인원 100명 중 평균적으로 52명 정도만 신청이 되는 이슈 발생
- 낙관적/비관적 락을 적용하여 db row 자체를 잠금
- redisson을 이용한 분산락 적용으로 동시성 제어(애플리케이션 내 진입을 순차별로 처리)
- 락 획득 -> db 잠금 -> 이벤트 참여자 수 카운트 증가 -> 커밋 

## Describe your code

- 코드 설명 (설명이 필요한 코드가 있다고 생각하시면 간단하게 작성해주세요.)

# Check
- [ ] Reviewers 등록을 하였나요?
- [ ] Assignees 등록을 하였나요?
- [ ] 라벨 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
