### PR TITLE
[REFACTOR] 알림 비동기 처리, 재시도/백오프 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
 
     // fcm
     implementation 'com.google.firebase:firebase-admin:9.1.1'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework:spring-aspects'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
     // ssr
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
@@ -74,7 +77,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'com.github.loki4j:loki-logback-appender:1.4.1'
-
 
 }
 

--- a/src/main/java/project/luckybooky/domain/notification/listener/HostNotificationListener.java
+++ b/src/main/java/project/luckybooky/domain/notification/listener/HostNotificationListener.java
@@ -1,53 +1,75 @@
 package project.luckybooky.domain.notification.listener;
 
+import com.google.api.core.ApiFuture;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import project.luckybooky.domain.notification.converter.NotificationConverter;
 import project.luckybooky.domain.notification.event.HostNotificationEvent;
-import project.luckybooky.domain.notification.service.NotificationService;
 import project.luckybooky.domain.user.entity.User;
 import project.luckybooky.domain.user.repository.UserRepository;
 import project.luckybooky.global.apiPayload.error.dto.ErrorCode;
 import project.luckybooky.global.apiPayload.error.exception.BusinessException;
+
 
 @Component
 @Slf4j
 @RequiredArgsConstructor
 public class HostNotificationListener {
     private final UserRepository userRepository;
-    private final NotificationService notificationService;
+    private final RabbitTemplate rabbitTemplate;
 
+    private static final Set<String> sentKeys = ConcurrentHashMap.newKeySet();
+    private static final String DLQ_QUEUE = "notification.dlq";
+
+    @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void onHostNotification(HostNotificationEvent evt) {
-        log.info("▶ 준비된 Host 알림: userId={}, type={}, eventName={}",
-                evt.getHostUserId(), evt.getType(), evt.getEventName());
+    @Retryable(
+            value = {FirebaseMessagingException.class, ExecutionException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000, multiplier = 2)
+    )
+    public void onHostNotification(HostNotificationEvent evt) throws Exception {
+        String idKey = evt.getType() + ":" + evt.getEventId() + ":" + evt.getHostUserId();
+        log.info("▶ 처리 시작 [{}]", idKey);
+
+        if (!sentKeys.add(idKey)) {
+            log.info("🛡️ 이미 전송됨 [{}] 스킵", idKey);
+            return;
+        }
 
         User host = userRepository.findById(evt.getHostUserId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         Message msg = NotificationConverter.toFcmMessage(host, evt.getType(), evt.getEventName(), evt.getEventId());
-
         if (msg == null) {
-            log.warn("⚠ FCM 토큰 미등록. (보냈어야 할 메시지) title='{}', body='{}'",
-                    evt.getType().getTitle(),
-                    evt.getType().formatBody(evt.getEventName()));
+            log.warn("⚠ 토큰 미등록 [{}]", idKey);
             return;
         }
 
-        try {
-            notificationService.send(msg);
-            log.info("✅ FCM 전송 성공: title='{}'  body='{}'",
-                    evt.getType().getTitle(),
-                    evt.getType().formatBody(evt.getEventName()));
-        } catch (Exception e) {
-            log.error("❌ FCM 전송 실패: title='{}'  body='{}'",
-                    evt.getType().getTitle(),
-                    evt.getType().formatBody(evt.getEventName()),
-                    e);
-        }
+        ApiFuture<String> future = FirebaseMessaging.getInstance().sendAsync(msg);
+        future.get();
+
+        log.info("✅ 전송 성공 [{}]", idKey);
+    }
+
+    @Recover
+    public void recover(Exception e, HostNotificationEvent evt) {
+        String idKey = evt.getType() + ":" + evt.getEventId() + ":" + evt.getHostUserId();
+        log.error("❌ 전송 실패 [{}], DLQ 전송: {}", idKey, e.getMessage());
+        rabbitTemplate.convertAndSend("", DLQ_QUEUE, evt);
     }
 }

--- a/src/main/java/project/luckybooky/domain/notification/listener/ParticipantNotificationListener.java
+++ b/src/main/java/project/luckybooky/domain/notification/listener/ParticipantNotificationListener.java
@@ -1,63 +1,78 @@
 package project.luckybooky.domain.notification.listener;
 
+import com.google.api.core.ApiFuture;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import project.luckybooky.domain.notification.converter.NotificationConverter;
 import project.luckybooky.domain.notification.event.ParticipantNotificationEvent;
-import project.luckybooky.domain.notification.service.NotificationService;
-import project.luckybooky.domain.notification.type.ParticipantNotificationType;
 import project.luckybooky.domain.user.entity.User;
 import project.luckybooky.domain.user.repository.UserRepository;
 import project.luckybooky.global.apiPayload.error.dto.ErrorCode;
 import project.luckybooky.global.apiPayload.error.exception.BusinessException;
 
+/**
+ * 참여자 알림: 비동기 FCM 전송 및 재시도/백오프, 멱등성 검사, DLQ 전송
+ */
 @Component
 @Slf4j
 @RequiredArgsConstructor
 public class ParticipantNotificationListener {
     private final UserRepository userRepository;
-    private final NotificationService notificationService;
+    private final RabbitTemplate rabbitTemplate;
 
-    @EventListener
-    public void onParticipantNotification(ParticipantNotificationEvent evt) {
+    private static final Set<String> sentKeys = ConcurrentHashMap.newKeySet();
+    private static final String DLQ_QUEUE = "notification.dlq";
 
-        Long participantId = evt.getUserId();
-        ParticipantNotificationType type = evt.getType();
-        String eventName = evt.getEventName();
+    @Async("notificationExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Retryable(
+            value = {FirebaseMessagingException.class, ExecutionException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000, multiplier = 2)
+    )
+    public void onParticipantNotification(ParticipantNotificationEvent evt) throws Exception {
+        String idKey = evt.getType() + ":" + evt.getEventId() + ":" + evt.getUserId();
+        log.info("▶ 처리 시작 [{}]", idKey);
 
-        User participant = userRepository.findById(participantId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
-        Message msg = NotificationConverter.toFcmMessageParticipant(participant, type, eventName, evt.getEventId());
-
-        log.info("📨 ParticipantNotification 시도: userId={} title='{}' body='{}'",
-                participantId,
-                type.getTitle(),
-                type.formatBody(eventName));
-
-        log.info("📨 ParticipantNotification 시도: userId={} title='{}' body='{}'",
-                participant.getId(),
-                evt.getType().getTitle(),
-                evt.getType().formatBody(evt.getEventName()));
-
-        if (msg == null) {
-            log.warn("⚠️ FCM 토큰 미등록으로 알림을 전송하지 않습니다. userId={}", participant.getId());
+        if (!sentKeys.add(idKey)) {
+            log.info("🛡️ 이미 전송됨 [{}] 스킵", idKey);
             return;
         }
 
-        try {
-            notificationService.send(msg);
-            log.info("✅ FCM 전송 성공: title='{}'  body='{}'",
-                    evt.getType().getTitle(),
-                    evt.getType().formatBody(evt.getEventName()));
-        } catch (Exception e) {
-            log.error("❌ FCM 전송 실패: title='{}'  body='{}'",
-                    evt.getType().getTitle(),
-                    evt.getType().formatBody(evt.getEventName()),
-                    e);
+        User participant = userRepository.findById(evt.getUserId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Message msg = NotificationConverter.toFcmMessageParticipant(participant, evt.getType(), evt.getEventName(),
+                evt.getEventId());
+        if (msg == null) {
+            log.warn("⚠ 토큰 미등록 [{}]", idKey);
+            return;
         }
+
+        ApiFuture<String> future = FirebaseMessaging.getInstance().sendAsync(msg);
+        future.get();
+
+        log.info("✅ 전송 성공 [{}]", idKey);
+    }
+
+    @Recover
+    public void recover(Exception e, ParticipantNotificationEvent evt) {
+        String idKey = evt.getType() + ":" + evt.getEventId() + ":" + evt.getUserId();
+        log.error("❌ 전송 실패 [{}], DLQ 전송: {}", idKey, e.getMessage());
+        rabbitTemplate.convertAndSend("", DLQ_QUEUE, evt);
     }
 }

--- a/src/main/java/project/luckybooky/global/config/AsyncConfig.java
+++ b/src/main/java/project/luckybooky/global/config/AsyncConfig.java
@@ -3,11 +3,13 @@ package project.luckybooky.global.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 @EnableAsync
+@EnableRetry
 public class AsyncConfig {
     @Bean("mailExecutor")
     public TaskExecutor mailExecutor() {
@@ -30,5 +32,15 @@ public class AsyncConfig {
         exec.initialize();
         return exec;
     }
-}
 
+    @Bean(name = "notificationExecutor")
+    public TaskExecutor notificationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(50);
+        executor.setMaxPoolSize(200);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("notif-exec-");
+        executor.initialize();
+        return executor;
+    }
+}


### PR DESCRIPTION
## Issue

- #155

## Summary

- 알림 전송 로직을 비동기 처리로 수정 -> 대량으로 알림 전송 시 메인 흐름이 느려지고 블로킹 되는 원인을 해결하고자 리팩토링 진행
- ConcurrentHashMap 집합으로 멱등성 키를 관리해 스레드 간 중복 전송을 방지하고, 재시도 모두 실패한 메시지는 RabbitMQ DLQ를 통해 복구가 가능하도록 설정
- 전용 스레드풀 구성
- firebase sdk의 비동기 전송, future.get()을 이용해 예외 감지, 자동 재시도 구현

## Describe your code

- 코드 설명 (설명이 필요한 코드가 있다고 생각하시면 간단하게 작성해주세요.)

# Check
- [ ] Reviewers 등록을 하였나요?
- [ ] Assignees 등록을 하였나요?
- [ ] 라벨 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
