### PR TITLE
[REFACTOR] 회원 탈퇴 시 회원과 연관된 이벤트 처리

### DIFF
--- a/src/main/java/project/luckybooky/domain/event/converter/EventConverter.java
+++ b/src/main/java/project/luckybooky/domain/event/converter/EventConverter.java
@@ -5,6 +5,7 @@ import project.luckybooky.domain.event.dto.request.EventRequest;
 import project.luckybooky.domain.event.dto.response.EventResponse;
 import project.luckybooky.domain.event.entity.Event;
 import project.luckybooky.domain.location.entity.Location;
+import project.luckybooky.domain.user.entity.User;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -70,9 +71,7 @@ public class EventConverter {
 
     public static EventResponse.EventReadDetailsResultDTO toEventReadDetailsResultDTO(
             Event event,
-            String username,
-            String userImageUrl,
-            Integer recruitment,
+            User host,
             String userRole,
             String recruitmentDate,
             Integer recruitmentRate,
@@ -96,6 +95,15 @@ public class EventConverter {
         LocalTime localTime = LocalTime.parse(event.getEventStartTime(), DateTimeFormatter.ofPattern("HH:mm"));
         String eventTime = localTime.format(DateTimeFormatter.ofPattern("HH시 mm분"));
 
+        // 주최자 처리
+        String username = "알 수 없음";
+        String userImageUrl = null;
+        Integer recruitment = 0;
+        if (host != null) {
+            username = host.getUsername();
+            userImageUrl = host.getProfileImage();
+            recruitment = host.getRecruitment();
+        }
         return EventResponse.EventReadDetailsResultDTO.builder()
                 .eventId(event.getId())
                 .mediaType(event.getCategory().getCategoryName())

--- a/src/main/java/project/luckybooky/domain/event/service/EventService.java
+++ b/src/main/java/project/luckybooky/domain/event/service/EventService.java
@@ -192,9 +192,7 @@ public class EventService {
 
         return EventConverter.toEventReadDetailsResultDTO(
                 event,
-                host.getUsername(),
-                host.getProfileImage(),
-                host.getHostExperienceCount(),
+                host,
                 userRole,
                 formatDateRange(event.getRecruitmentStart(), event.getRecruitmentEnd()),
                 Math.round((float) ((double) event.getCurrentParticipants() / event.getMaxParticipants()) * 100),

--- a/src/main/java/project/luckybooky/domain/participation/repository/ParticipationRepository.java
+++ b/src/main/java/project/luckybooky/domain/participation/repository/ParticipationRepository.java
@@ -16,8 +16,6 @@ import project.luckybooky.domain.user.entity.User;
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
     Optional<Participation> findByUserIdAndEventId(Long userId, Long eventId);
 
-    void deleteByUserIdAndEventId(Long userId, Long eventId);
-
     @Query("SELECT p.event FROM Participation p WHERE p.user.id = :userId AND p.participateRole = :participateRole AND p.event.eventStatus IN :statuses")
     Page<Event> findByUserIdAndEventStatuses(@Param("userId") Long userId,
                                              @Param("participateRole") ParticipateRole participateRole,
@@ -35,11 +33,7 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
     @Query("SELECT p.user FROM Participation p WHERE p.event.id = :eventId AND p.participateRole = 'HOST'")
     User findHostParticipationByEventId(@Param("eventId") Long eventId);
 
-    @Query("SELECT p.participateRole FROM Participation p WHERE p.event.id = :eventId AND p.user = :user")
-    Optional<ParticipateRole> findRoleByUser(@Param("eventId") Long eventId, @Param("user") User user);
-
-    @Query("SELECT p FROM Participation p JOIN FETCH p.user WHERE p.event.id = :eventId")
-    List<Participation> findAllWithUserByEventId(@Param("eventId") Long eventId);
+    List<Participation> findByUserId(Long userId);
 
     boolean existsByUserIdAndEventId(Long userId, Long eventId);
 

--- a/src/main/java/project/luckybooky/domain/participation/service/ParticipationService.java
+++ b/src/main/java/project/luckybooky/domain/participation/service/ParticipationService.java
@@ -111,6 +111,8 @@ public class ParticipationService {
                             throw new BusinessException(ErrorCode.EVENT_IN_PROGRESS);
                         }
                         break;
+                    default:
+                        break;
                 }
             } else {
                 switch (event.getParticipantEventButtonState()) {
@@ -123,6 +125,8 @@ public class ParticipationService {
                         if (event.getEventStatus().equals(EventStatus.VENUE_CONFIRMED)) {
                             throw new BusinessException(ErrorCode.EVENT_IN_PROGRESS);
                         }
+                        break;
+                    default:
                         break;
                 }
             }

--- a/src/main/java/project/luckybooky/domain/participation/service/ParticipationService.java
+++ b/src/main/java/project/luckybooky/domain/participation/service/ParticipationService.java
@@ -106,6 +106,11 @@ public class ParticipationService {
                     case VENUE_RESERVATION, VENUE_RESERVATION_IN_PROGRESS:
                         eventService.venueProcess(userId, event.getId(), 1);
                         break;
+                    case TO_TICKET:
+                        if (event.getEventStatus().equals(EventStatus.VENUE_CONFIRMED)) {
+                            throw new BusinessException(ErrorCode.EVENT_IN_PROGRESS);
+                        }
+                        break;
                 }
             } else {
                 switch (event.getParticipantEventButtonState()) {

--- a/src/main/java/project/luckybooky/domain/participation/service/ParticipationService.java
+++ b/src/main/java/project/luckybooky/domain/participation/service/ParticipationService.java
@@ -93,6 +93,7 @@ public class ParticipationService {
     /**
      * 회원 탈퇴 시 연관된 이벤트 취소
      **/
+    @Transactional
     public String cancelParticipation(Long userId) {
         List<Participation> participationList = participationRepository.findByUserId(userId);
         participationList.stream().forEach(p -> {

--- a/src/main/java/project/luckybooky/domain/participation/service/ParticipationService.java
+++ b/src/main/java/project/luckybooky/domain/participation/service/ParticipationService.java
@@ -12,6 +12,7 @@ import project.luckybooky.domain.event.converter.EventConverter;
 import project.luckybooky.domain.event.dto.response.EventResponse;
 import project.luckybooky.domain.event.entity.Event;
 import project.luckybooky.domain.event.entity.type.EventStatus;
+import project.luckybooky.domain.event.entity.type.HostEventButtonState;
 import project.luckybooky.domain.event.service.EventService;
 import project.luckybooky.domain.notification.event.ParticipantNotificationEvent;
 import project.luckybooky.domain.notification.type.ParticipantNotificationType;
@@ -88,4 +89,28 @@ public class ParticipationService {
                 }
         ).collect(Collectors.toList());
     }
+
+    /**
+     * 회원 탈퇴 시 연관된 이벤트 취소
+     **/
+    public String cancelParticipation(Long userId) {
+        List<Participation> participationList = participationRepository.findByUserId(userId);
+        participationList.stream().forEach(p -> {
+            Event event = p.getEvent();
+            if (p.getParticipateRole().equals(ParticipateRole.HOST)) {
+                switch (event.getHostEventButtonState()) {
+                    case RECRUIT_CANCELLED:
+                        eventService.cancelRecruitEvent(userId, event.getId());
+                        break;
+                    case VENUE_RESERVATION, VENUE_RESERVATION_IN_PROGRESS:
+                        eventService.venueProcess(userId, event.getId(), 1);
+                        break;
+                }
+            } else {
+                eventService.cancelEvent(userId, p.getEvent().getId());
+            }
+        });
+        return "정상 처리되었습니다.";
+    }
+
 }

--- a/src/main/java/project/luckybooky/domain/participation/service/ParticipationService.java
+++ b/src/main/java/project/luckybooky/domain/participation/service/ParticipationService.java
@@ -107,7 +107,18 @@ public class ParticipationService {
                         break;
                 }
             } else {
-                eventService.cancelEvent(userId, p.getEvent().getId());
+                switch (event.getParticipantEventButtonState()) {
+                    case REGISTER_CANCELED:
+                        eventService.cancelEvent(userId, event.getId());
+                        break;
+                    case RECRUIT_DONE, VENUE_RESERVATION_IN_PROGRESS:
+                        throw new BusinessException(ErrorCode.EVENT_IN_PROGRESS);
+                    case TO_TICKET:
+                        if (event.getEventStatus().equals(EventStatus.VENUE_CONFIRMED)) {
+                            throw new BusinessException(ErrorCode.EVENT_IN_PROGRESS);
+                        }
+                        break;
+                }
             }
         });
         return "정상 처리되었습니다.";

--- a/src/main/java/project/luckybooky/domain/user/controller/AuthController.java
+++ b/src/main/java/project/luckybooky/domain/user/controller/AuthController.java
@@ -54,7 +54,7 @@ public class AuthController {
     @Operation(summary = "회원탈퇴",
             description = "현재 로그인된 회원의 모든 연관 데이터를 삭제하고, 계정을 완전 제거합니다.")
     @DeleteMapping("/delete")
-    public BaseResponse<Void> deleteUser(HttpServletRequest request,
+    public BaseResponse<String> deleteUser(HttpServletRequest request,
                                          HttpServletResponse response) {
         return authService.deleteUser(request, response);
     }

--- a/src/main/java/project/luckybooky/domain/user/service/AuthService.java
+++ b/src/main/java/project/luckybooky/domain/user/service/AuthService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import project.luckybooky.domain.feedback.repository.FeedbackRepository;
 import project.luckybooky.domain.notification.repository.NotificationRepository;
 import project.luckybooky.domain.participation.repository.ParticipationRepository;
+import project.luckybooky.domain.participation.service.ParticipationService;
 import project.luckybooky.domain.user.converter.AuthConverter;
 import project.luckybooky.domain.user.converter.UserConverter;
 import project.luckybooky.domain.user.dto.response.UserResponseDTO;
@@ -31,13 +32,11 @@ import project.luckybooky.global.oauth.util.KakaoUtil;
 @RequiredArgsConstructor
 @Slf4j
 public class AuthService {
-    private final NotificationRepository notificationRepository;
     private final KakaoUtil kakaoUtil;
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
     private final TokenService tokenService;
-    private final FeedbackRepository feedbackRepository;
-    private final ParticipationRepository participationRepository;
+    private final ParticipationService participationService;
 
 
     @Transactional
@@ -197,7 +196,10 @@ public class AuthService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         Long userId = user.getId();
 
-        // 2) User 삭제 (cascade 설정으로 Feedback, Notification, Participation 모두 함께 삭제)
+        // 2) 연관된 이벤트 취소 처리
+        participationService.cancelParticipation(userId);
+
+        // 3) User 삭제 (cascade 설정으로 Feedback, Notification, Participation 모두 함께 삭제)
         userRepository.delete(user);
 
         // 3) Redis에 남은 리프레시 토큰 삭제

--- a/src/main/java/project/luckybooky/domain/user/service/AuthService.java
+++ b/src/main/java/project/luckybooky/domain/user/service/AuthService.java
@@ -202,7 +202,7 @@ public class AuthService {
         // 3) User 삭제 (cascade 설정으로 Feedback, Notification, Participation 모두 함께 삭제)
         userRepository.delete(user);
 
-        // 3) Redis에 남은 리프레시 토큰 삭제
+        // 4) Redis에 남은 리프레시 토큰 삭제
         tokenService.deleteAllRefreshTokens(userId);
 
         boolean isLocal = false;
@@ -211,7 +211,7 @@ public class AuthService {
             isLocal = true;
         }
 
-        // 4) 클라이언트 쿠키 만료
+        // 5) 클라이언트 쿠키 만료
         CookieUtil.deleteCookie(response, "accessToken", isLocal);
         CookieUtil.deleteCookie(response, "refreshToken", isLocal);
 

--- a/src/main/java/project/luckybooky/domain/user/service/AuthService.java
+++ b/src/main/java/project/luckybooky/domain/user/service/AuthService.java
@@ -187,7 +187,7 @@ public class AuthService {
     }
 
     @Transactional
-    public BaseResponse<Void> deleteUser(HttpServletRequest request,
+    public BaseResponse<String> deleteUser(HttpServletRequest request,
                                          HttpServletResponse response) {
 
         // 1) 현재 유저 조회
@@ -215,6 +215,6 @@ public class AuthService {
         CookieUtil.deleteCookie(response, "accessToken", isLocal);
         CookieUtil.deleteCookie(response, "refreshToken", isLocal);
 
-        return BaseResponse.onSuccess(null);
+        return BaseResponse.onSuccess("정상 처리되었습니다.");
     }
 }

--- a/src/main/java/project/luckybooky/global/apiPayload/error/dto/ErrorCode.java
+++ b/src/main/java/project/luckybooky/global/apiPayload/error/dto/ErrorCode.java
@@ -74,6 +74,7 @@ public enum ErrorCode implements BaseStatus {
     // Participation 관련
     PARTICIPATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "PARTICIPATION_401", "해당 이벤트를 참여하지 않았습니다."),
     PARTICIPATION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "PARTICIPATION_402", "해당 이벤트의 주최자가 아닙니다."),
+    EVENT_IN_PROGRESS(HttpStatus.BAD_REQUEST, "PARTICIPATION_403", "아직 끝나지 않은 이벤트가 있습니다."),
 
     // Notification 관련
     NOTIFICATION_FCM_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "NOTIFICATION_400", "FCM 토큰이 등록되지 않았습니다."),


### PR DESCRIPTION
## Issue

- #176 


## Summary

**회원 탈퇴 시, 연관된 이벤트가 존재하는 경우 후처리 작업을 수행하였습니다.**
- 주최자, 참여자인 경우 모두 모집 완료 후 상영 종료 전까지의 단계인 이벤트 존재 시 탈퇴 불가 처리, 나머지 상태는 탈퇴 가능.
- 주최자인 경우: 모집 중인 이벤트 존재 시 모집 취소 처리 후 탈퇴.
      - 추가로 탈퇴 후 이벤트 상세 조회 시 주최자 정보 '알 수 없음'으로 처리.
- 신청자인 경우: 모집 중인 이벤트 존재 시 신청 취소 처리 후 탈퇴.

## Describe your code

- 코드 설명 (설명이 필요한 코드가 있다고 생각하시면 간단하게 작성해주세요.)

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
