### PR TITLE
[FIX] 링크 생성 오류 수정

### DIFF
--- a/src/main/java/project/luckybooky/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/project/luckybooky/domain/notification/converter/NotificationConverter.java
@@ -108,6 +108,8 @@ public class NotificationConverter {
         var ev = hostParticipation.getEvent();
 
         return ConfirmedData.builder()
+                .eventId(ev.getId())
+                .hostName(hostParticipation.getUser().getUsername())
                 .mediaTitle(ev.getMediaTitle())
                 .eventTitle(ev.getEventTitle())
                 .eventDate(ev.getEventDate())
@@ -119,7 +121,6 @@ public class NotificationConverter {
                 .locationName(ev.getLocation().getLocationName())
                 .maxParticipants(ev.getMaxParticipants())
                 .contact("")
-                .participantsLink(homeUrl + "/events/" + ev.getId() + "/participants")
                 .build();
     }
 

--- a/src/main/java/project/luckybooky/domain/notification/service/MailTemplateService.java
+++ b/src/main/java/project/luckybooky/domain/notification/service/MailTemplateService.java
@@ -34,6 +34,11 @@ public class MailTemplateService {
     private final ResourceLoader resourceLoader;
 
     public void sendVenueConfirmedMail(String to, ConfirmedData data) {
+
+        if (data.getEventId() == null) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+
         Context ctx = new Context();
         ctx.setVariable("mediaTitle", data.getMediaTitle());
         ctx.setVariable("eventTitle", data.getEventTitle());
@@ -43,10 +48,9 @@ public class MailTemplateService {
         ctx.setVariable("venue", data.getLocationName());
         ctx.setVariable("capacity", formatCapacity(data.getMaxParticipants()));
         ctx.setVariable("contact", data.getContact() != null ? data.getContact() : "");
-        ctx.setVariable("participantsLink", String.format("%s/events/%d/participants", homeUrl, data.getEventId()));
+        ctx.setVariable("participantsLink", buildParticipantsLink(data.getEventId()));
         ctx.setVariable("homeUrl", homeUrl);
 
-        // 2) 템플릿과 CID 자원 정보 전달
         sendTemplateMail(
                 to,
                 "[MovieBookie] 대관 확정 안내: " + data.getEventTitle(),
@@ -122,9 +126,13 @@ public class MailTemplateService {
                 : "정보 없음";
     }
 
-    /**
-     * 내부에서만 쓰이는 CID + 리소스 경로 묶음
-     */
     private static record InlineResource(String cid, String path) {
+    }
+
+    private String buildParticipantsLink(Long eventId) {
+        String base = (homeUrl != null && homeUrl.endsWith("/"))
+                ? homeUrl.substring(0, homeUrl.length() - 1)
+                : homeUrl;
+        return base + "/events/" + eventId + "/participants";
     }
 }


### PR DESCRIPTION
참여자 정보 확인 링크 생성하는 로직을 MailTemplateService에서만 실행하도록 수정

## Issue

- #205 


## Summary

- 참여자 정보 확인 링크 생성 과정에서 eventId가 null로 들어가는 문제 해결
<img width="639" height="47" alt="스크린샷 2025-08-10 오후 7 58 36" src="https://github.com/user-attachments/assets/6d149c5f-2ceb-4d77-8a60-c4558a4b81a4" />


## Describe your code

- 코드 설명 (설명이 필요한 코드가 있다고 생각하시면 간단하게 작성해주세요.)

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
