### PR TITLE
[FEAT] 네임드락을 활용하여 일정 겹치는 이벤트 동시 생성 방지 

### DIFF
--- a/src/main/java/project/luckybooky/domain/event/repository/EventRepository.java
+++ b/src/main/java/project/luckybooky/domain/event/repository/EventRepository.java
@@ -51,4 +51,17 @@ public interface EventRepository extends JpaRepository<Event, Long> {
             @Param("startTime") String startTime,
             @Param("endTime") String endTime
     );
+
+    /** 시간대 겹치는 영화관 개수 **/
+    @Query("SELECT COUNT(e) FROM Event e " +
+            "where e.location.id = :locationId " +
+            "AND e.eventDate = :date " +
+            "AND (e.eventStartTime < :endTime) AND (:startTime < e.eventEndTime)")
+    Integer isExistOverlappingLocationsByTime(
+            @Param("locationId") Long locationId,
+            @Param("date") LocalDate date,
+            @Param("startTime") String startTime,
+            @Param("endTime") String endTime
+    );
+
 }

--- a/src/main/java/project/luckybooky/domain/event/service/EventService.java
+++ b/src/main/java/project/luckybooky/domain/event/service/EventService.java
@@ -70,18 +70,18 @@ public class EventService {
      **/
     @Transactional
     public Long createEvent(Long userId, EventRequest.EventCreateRequestDTO request, MultipartFile eventImage) {
-        // 해당 날짜에 이미 참여한 이벤트 없는지 검증
-        if (isNotParticipatedOnDate(userId, request.getEventDate())) {
-            throw new BusinessException(ErrorCode.EVENT_ALREADY_EXIST);
-        }
-
         String lockKey = buildLockKey(request.getLocationId(), request.getEventDate());
         boolean locked = false;
         try {
             // 락 획득 시도
-            locked = lockRepository.getLock(lockKey, 2);
+            locked = lockRepository.getLock(lockKey, 5);
             if (!locked) {
                 throw new BusinessException(ErrorCode.LOCATION_DATE_LOCKED);
+            }
+
+            // 해당 날짜에 이미 참여한 이벤트 없는지 검증
+            if (isNotParticipatedOnDate(userId, request.getEventDate())) {
+                throw new BusinessException(ErrorCode.EVENT_ALREADY_EXIST);
             }
 
             // 영화관 검증

--- a/src/main/java/project/luckybooky/domain/event/service/EventService.java
+++ b/src/main/java/project/luckybooky/domain/event/service/EventService.java
@@ -74,7 +74,7 @@ public class EventService {
         boolean locked = false;
         try {
             // 락 획득 시도
-            locked = lockRepository.getLock(lockKey, 5);
+            locked = lockRepository.getLock(lockKey, 10);
             if (!locked) {
                 throw new BusinessException(ErrorCode.LOCATION_DATE_LOCKED);
             }

--- a/src/main/java/project/luckybooky/global/apiPayload/error/dto/ErrorCode.java
+++ b/src/main/java/project/luckybooky/global/apiPayload/error/dto/ErrorCode.java
@@ -55,6 +55,8 @@ public enum ErrorCode implements BaseStatus {
 
     // location 관련
     LOCATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "LOCATION_401", "영화관을 찾을 수 없습니다."),
+    LOCATION_ALREADY_RESERVED(HttpStatus.BAD_REQUEST, "LOCATION_402", "이미 같은 시간대에 예약된 영화관입니다."),
+    LOCATION_DATE_LOCKED(HttpStatus.BAD_REQUEST, "LOCATION_403", "동일 영화관/날짜 작업 중입니다. 잠시 후 재시도 바랍니다."),
 
     // category 관련
     CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "CATEGORY_401", "카테고리를 찾을 수 없습니다."),


### PR DESCRIPTION
## Issue

- #199 


## Summary

- 영화관 일정이 겹치는 여러 이벤트가 동시에 생성되는 문제를 해결하기 위해 MySQL 네임드락을 적용하였습니다.
- '영화관이름+날짜'를 락으로 설정하여, 락 경합 상황을 최소화하였습니다.
- 처리 과정
     - `락 획득 -> 일정 겹치는 이벤트 조회 -> 없다면 이벤트 생성 -> 락 반납`

## Describe your code

- 코드 설명 (설명이 필요한 코드가 있다고 생각하시면 간단하게 작성해주세요.)

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
