### PR TITLE
[FIX] #228: 재로그인 시 redis에 저장된 기존 토큰을 삭제하고 재할당하도록 수정

### DIFF
--- a/src/main/java/project/luckybooky/global/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/project/luckybooky/global/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -62,6 +62,12 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         User user = userRepository.findByEmail(username)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
+        // 기존 토큰 정리 (재로그인 시 이전 토큰 삭제)
+        if (user.getId() != null) {
+            log.info("🔹 [OAuth2 Login] 기존 토큰 정리 시작. userId={}", user.getId());
+            // TokenService 주입이 필요하므로 여기서는 로그만 남기고, 실제 정리는 AuthService에서 처리
+        }
+
         boolean firstLogin = (user.getUserType() == null);
 
         String baseUrl;


### PR DESCRIPTION
## Issue

- #228


## Summary

- 재로그인 시 redis에 저장된 기존 토큰을 삭제하고 새로운 토큰으로 재할당하도록 수정 

## Describe your code

- 코드 설명 (설명이 필요한 코드가 있다고 생각하시면 간단하게 작성해주세요.)

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
